### PR TITLE
Don't overtrim whitespace in templates/ingress.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: adminer
 appVersion: 4.8.1
-version: 0.1.7
+version: 0.1.8
 description: Adminer is a full-featured database management tool written in PHP. Conversely to phpMyAdmin, it consist of a single file ready to deploy to the target server. Adminer is available for MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, Firebird, SimpleDB, Elasticsearch and MongoDB
 home: https://www.adminer.org
 icon: https://raw.githubusercontent.com/Kong/docker-official-docs/master/adminer/logo.png

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled -}}
 {{- $fullName := include "adminer.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes a problem that occurs with a recent version of helm/helmfile where trimming the whitespace to the left and right side of the first if-statement in the ingress template causes the line declaring the `apiVersion` property to jump onto the same line as the document separator `---` when running `helmfile lint`. It does not affect the ingress definition iteself.

The concrete error occurs when running `helmfile lint` in a repository that uses the latest version of this helm chart (v0.1.7) is:
```
Linting release=adminer-cetic, chart=/tmp/helmfile007485966/default/adminer-cetic/cetic/adminer/v0.1.7/adminer
--
==> Linting /tmp/helmfile007485966/default/adminer-cetic/cetic/adminer/v0.1.7/adminer
[ERROR] templates/ingress.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: extensions/v1beta1
```

The error is identical to the one I get when attempting to lint a file that starts with `---apiVersion: ...` (no newlines) and makes some sense since `{{- if ... -}}` trims whitespace (including newlines!) to the left and to the right of the if-statement according to [the docs](https://v3-1-0.helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace).

#### Special notes for your reviewer:

I believe this is related to this helm issue https://github.com/helm/helm/issues/10149 which describes a similar problem.

The issue was reproducible on two developer machines running helm v3.7.x and helmfile v0.141.0. A colleague who was still on helm v3.6.2 and helmfile v0.140.1 did not have this issue.

I verified locally that with this change `helmfile lint` stops complaining.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
